### PR TITLE
Update docs and don't compile subtitles or drm

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 
 [comment]: <> ([![Sauce Test Status]&#40;https://saucelabs.com/browser-matrix/robwalch.svg&#41;]&#40;https://saucelabs.com/u/robwalch&#41;)
 
+# WISTIA HLS
+
+This is the Wistia Fork of HLS.js. We have forked HLS.js so that we can make tweaks to the HLS.js scripts as necessary so HLS.js can be optimized for Wistia playback.
+
+## Docs 📓
+
+- [Deploying 🚀](/docs/deploying.md)
+- [Developing Locally 👩‍💻](/docs/developing-locally.md)
+
 # ![HLS.js](https://cloud.githubusercontent.com/assets/616833/19739063/e10be95a-9bb9-11e6-8100-2896f8500138.png)
 
 HLS.js is a JavaScript library that implements an [HTTP Live Streaming] client.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,33 @@
+# Deploying 🚀
+
+We deploy our forked version of HLS.js via npm.
+
+## Steps to Deploy
+
+1. run `yarn version` from the `master` branch, fill out the form, and push up your commit
+1. run `npm login` and log into `npm` using the NPM credentials in 1Password
+1. run `npm publish`
+
+For the version number, we keep the base version that we are currently forked against from Hls.js _plus_ a semver prelease version. E.g. `1.0.4-4`.
+
+## Creating a Github Release
+
+To help us keep track of Wistia HLS changes, it is also expected to create an associated Github Release.
+
+To keep things simple, our release version number should make that of the NPM version we have just deployed.
+
+The release message should try and document all the big changes that have happened and a link to the diff between versions.
+
+```
+* my awesome change
+* some other thing
+* BREAKING:
+  * Now only supports dog videos
+
+https://github.com/wistia/hls.js/compare/v1.2.3...v1.2.4
+
+```
+
+## Updating player-modern
+
+You will also need to go and update player-modern with your new npm release and deploy the player

--- a/docs/developing-locally.md
+++ b/docs/developing-locally.md
@@ -1,0 +1,24 @@
+# Developing Locally 👩‍💻
+
+To change and develop HLS.js locally, the follow steps are required
+
+## In this repository
+
+1. run `yarn link` - https://classic.yarnpkg.com/en/docs/cli/link/
+1. run `yarn run build:watch` <- this will start up the HLS.js server and watch for changes
+
+## In player-modern
+
+1. stop your local server if running
+1. run `yarn link @wistia/hls.js`
+1. start your player-modern server as normal
+
+## When you're finished
+
+https://classic.yarnpkg.com/en/docs/cli/unlink
+
+1. stop your player-modern server and the hls.js server
+1. run `yarn unlink @wistia/hls.js` from player-modern
+   2.1 you could also run `yarn unlink` from this repository
+1. run `yarn` in player-modern before restarting
+   3.1 if you get compilation errors you may need to run `yarn install --force`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,10 +13,12 @@ const addEMESupport = !!env.EME_DRM || !!env.USE_EME_DRM;
 
 const createDefinePlugin = (type) => {
   const buildConstants = {
+    // WISTIA HLS CHANGE: we don't ever want to compile the subtitles or
+    // drm stuff because we don't use it
     __VERSION__: JSON.stringify(pkgJson.version),
-    __USE_SUBTITLES__: JSON.stringify(type === 'main' || addSubtitleSupport),
+    __USE_SUBTITLES__: false,
     __USE_ALT_AUDIO__: JSON.stringify(type === 'main' || addAltAudioSupport),
-    __USE_EME_DRM__: JSON.stringify(type === 'main' || addEMESupport),
+    __USE_EME_DRM__: false,
   };
   return new webpack.DefinePlugin(buildConstants);
 };


### PR DESCRIPTION
This pr updates the docs and stops webpack from compiling subtitles or drm