### PR TITLE
Include Default ABR Controller in hls.js bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,7 +122,6 @@ const baseConfig = {
 
 function getAliasesForMainAndDebugDist() {
   return {
-    './controller/abr-controller': './empty.js',
     './controller/eme-controller': './empty.js',
     './controller/subtitle-stream-controller': './empty.js',
     './controller/subtitle-track-controller': './empty.js',


### PR DESCRIPTION
Wistia Live Video will not be return stream metadata in the same way the VOD videos do at Wistia. This means that our current, custom ABR Controller will not work for live streaming. We're going to use the default ABR Controller for that instance. 

This PR makes sure the Default ABR Controller is included in the hls.js bundle for us to use.