### PR TITLE
Comment out the code that strips the start delimiter bytes

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -878,10 +878,11 @@ class TSDemuxer implements Demuxer {
               // check if lastUnit had a state different from zero
               if (lastUnit.state) {
                 // strip last bytes
-                lastUnit.data = lastUnit.data.subarray(
-                  0,
-                  lastUnit.data.byteLength - lastState
-                );
+                console.log('start delimiter overlapping');
+                // lastUnit.data = lastUnit.data.subarray(
+                //   0,
+                //   lastUnit.data.byteLength - lastState
+                // );
               }
             }
             // If NAL units are not starting right at the beginning of the PES packet, push preceding data into previous NAL unit.


### PR DESCRIPTION
Related to https://github.com/video-dev/hls.js/issues/3834

This will comment out the code stripping the start delimiter bytes allowing us to test across multiple devices